### PR TITLE
removing sample pages from production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lib": "lib"
   },
   "scripts": {
-    "serve": "eleventy --serve & npm run sass:watch",
+    "build": "ELEVENTY_ENV=production eleventy",
+    "serve": "ELEVENTY_ENV=development eleventy --serve & npm run sass:watch",
     "sass:watch": "sass --watch src/assets/styles/sass/style.scss:src/assets/styles/style.css",
     "screenshots": "npm run screenshots:js && npm run screenshots:html && npm run screenshots:css",
     "screenshots:js": "node take_screenshots.js --lang js --theme light --font \"$FONT\" && node take_screenshots.js --lang js --theme dark --font \"$FONT\"",

--- a/src/code_samples/code_samples.11tydata.js
+++ b/src/code_samples/code_samples.11tydata.js
@@ -1,0 +1,3 @@
+module.exports = {
+  permalink: process.env.ELEVENTY_ENV === 'production' ? false : '/code_samples/{{ page.fileSlug }}/'
+}


### PR DESCRIPTION
The sample pages aren't very useful to visitors without knowing the query parameters and having fonts installed. Probably best to only create them in dev.