### PR TITLE
Fix `ligatures` flag for Recursive font

### DIFF
--- a/src/fonts/recursive.md
+++ b/src/fonts/recursive.md
@@ -10,7 +10,7 @@ repo_url: https://github.com/arrowtype/recursive
 license:
   - name: SIL OPEN FONT LICENSE
     url: https://github.com/arrowtype/recursive/blob/main/OFL.txt
-ligatures: false
+ligatures: true
 italics: true
 variable: true
 stylesheet_url: recursive/style.css


### PR DESCRIPTION
[Recursive](https://coding-fonts.css-tricks.com/fonts/recursive/?language=charmap) font seems to support ligatures. On the website it shows that it doesn't. This PR fixes that.

<img width="1105" alt="ligatures" src="https://user-images.githubusercontent.com/911894/99614887-fe769f00-2a4c-11eb-92ba-58df9ac13d67.png">

Cheers,