### PR TITLE
Clearer instructions to Add Fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://coding-fonts.css-tricks.com/
 - Make a stylesheet that gets that font ready to use in that font folder. e.g. `/src/assets/fonts/NewFont/NewFont.css`
 - Add a file like `new-font.md` to `/src/fonts`. Add the font's information. Mark the URL of the stylesheet from the previous step in the `stylesheet_url` field, relative to `/src/assets/fonts/`. If the URL is absolute, i.e. not added to the repo, add a `stylesheet_absolute: true` field. [See this one](https://github.com/chriscoyier/coding-fonts/blob/master/src/fonts/Fira%20Code.md) as an example.
 - To preview what will be screenshot, the URL structure is like: http://localhost:8080/code_samples/html/?font=Anonymous%20Pro&theme=dark
-- Run the screenshots! This is a local-only process. At the command line: `FONT='consolas' npm run screenshots`. You can change `FONT` to a font name matching the name of the Markdown file that you created.
+- Run the screenshots! This is a local-only process. At the command line: `FONT='consolas' npm run screenshots`. You can change `FONT` to a font name matching the kebab-case `Title` of the Markdown file that you created.
 
 Then make a Pull Request for it. You should be able to see a built preview on Netlify as part of the PR.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://coding-fonts.css-tricks.com/
 - If the font is open source, put a copy of the font in the `fonts` folder. At the very least a `.woff2` file in a folder of the fonts name. e.g. `/src/assets/fonts/NewFont/NewFont.woff2`
 - Make a stylesheet that gets that font ready to use in that font folder. e.g. `/src/assets/fonts/NewFont/NewFont.css`
 - Add a file like `new-font.md` to `/src/fonts`. Add the font's information. Mark the URL of the stylesheet from the previous step in the `stylesheet_url` field, relative to `/src/assets/fonts/`. If the URL is absolute, i.e. not added to the repo, add a `stylesheet_absolute: true` field. [See this one](https://github.com/chriscoyier/coding-fonts/blob/master/src/fonts/Fira%20Code.md) as an example.
-- To preview what will be screenshot, the URL structure is like: http://localhost:8080/code_samples/html/?font=Anonymous%20Pro&theme=dark
+- To preview what will be screenshot, the URL structure is like: http://localhost:8080/code_samples/html/?font=anonymous-pro&theme=dark where font matches the kebab-case `Title` of the Markdown file that you created.
 - Run the screenshots! This is a local-only process. At the command line: `FONT='consolas' npm run screenshots`. You can change `FONT` to a font name matching the kebab-case `Title` of the Markdown file that you created.
 
 Then make a Pull Request for it. You should be able to see a built preview on Netlify as part of the PR.


### PR DESCRIPTION
When I was trying to add the font `Cartograph CF`, I ran into an issue where I couldn't preview the code samples and I couldn't get the screenshots to work. I was using the markdown file name, `cartograph.md` as the variable, but nothing seems to work. After doing a little bit of digging, I found that `dist` was creating the page with a path of `/cartograph-cf` instead of `/cartograph`. 

The `Title` in my `cartograph.md` file was `Cartograph CF`. Once I figured that out, I ran screenshots and the preview with `cartograph-cf` and everything worked.

I updated the README to call this out in case someone else ends up with a font title different from the name of their markdown file.