### PR TITLE
Respond to history changes (e.g. back button)

### DIFF
--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -34,7 +34,7 @@ function setStateFromUrlParams () {
   }
 }
 
-function goto (href) {
+function goto (href, pushToHistory) {
   function revertToRegularNavigation () {
     location.href = href;
   }
@@ -47,7 +47,7 @@ function goto (href) {
         $main = response.querySelector('[data-site-main]');
     if ($main) {
       document.querySelector('[data-site-main]').innerHTML = $main.innerHTML;
-      history.pushState({}, title, href);
+      if (pushToHistory) history.pushState({}, title, href);
       document.title = title;
       document.querySelectorAll('[data-nav-item]').forEach(function ($a) {
         $a.classList.toggle('active', $a.href === href || $a.getAttribute('href') === href)
@@ -85,7 +85,7 @@ function setupAjaxNavigation () {
         return
       }
 
-      goto(href);
+      goto(href, true);
     })
   })
 }
@@ -123,5 +123,9 @@ window.addEventListener('load', function () {
   setupLanguageControlsStyle();
   setupStickyObserver();
 })
+
+window.addEventListener('popstate', function() {
+  goto(document.location.href, false);
+});
 
 // TODO: polyfill URLSearchParams for IE11? (https://github.com/jerrybendy/url-search-params-polyfill)


### PR DESCRIPTION
Currently, the site does not respond to history changes, e.g. if a user clicks the back or forward button or navigates with the keyboard (e.g. cmd + left arrow).

With this PR, the site listens to history changes and responds accordingly.

(What I actually would like to have is a nice way to quickly toggle between two fonts to get a feeling for the (subtle) differences. With this PR, it is possible to do this by holding the command key and quickly click the left and right arrow, which is good enough for me.)