### PR TITLE
added open graph meta tags & twitter specific card data

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -7,10 +7,19 @@
     <link
       rel="stylesheet"
       href="https://cloud.typography.com/610186/6080612/css/fonts.css"
-/>
+    />
     <link rel="stylesheet" href="/assets/styles/style.css"/>
     <link rel='shortcut icon' type='image/x-icon' href='/favicon.ico' />
     <title>Coding Fonts{{' — ' + title if title}}</title>
+    {% if title %}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:site" content="@css" />
+      <meta name="twitter:creator" content="@css" />
+      <meta property="og:url" content="{{images.imageLocation}}/fonts/{{title | slug}}/" />
+      <meta property="og:title" content="{{title}}" />
+      <meta property="og:description" content="font designed for writing code" />
+      <meta property="og:image" content="{{images.imageLocation}}/screenshots/{{title | slug}}/js-dark.png" />
+    {% endif %}
   </head>
 
   <body>


### PR DESCRIPTION
This adds Open Graph data and Twitter card specific meta as well: https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image

**Use case** would be when a user shares a direct link to one of these font specific pages: the image preview, font name etc is shared within this summary_large_image twitter card on their tweet.